### PR TITLE
Add action to download artifact

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,8 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: workflow_pushed_master.yml
-          commit: ${{ github.event.pull_request.base.sha }}
+          #commit: ${{ github.event.pull_request.base.sha }}
+          branch: master
           path: base_coverage
           name: my-artifact
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,3 +23,19 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           lcov-file: ./lcov.info
+
+  test-download-artifact:
+    name: Download coverage artifact
+    runs-on: ubuntu-18.04
+    steps:
+      - name: download artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: workflow_pushed_master.yml
+          commit: ${{ github.event.pull_request.base.sha }}
+          path: base_coverage
+          name: my-artifact
+
+      - name: show artifact
+        run: |
+          find base_coverage -type f

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,15 +18,25 @@ jobs:
           version: '0.13.3'
           args: ${{env.PARAMS}}
 
+      - name: Download coverage file (in artifact) for comparison
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: workflow_pushed_master.yml
+          branch: master
+          path: base_coverage
+          name: my-artifact
+
       - name: Apply code coverage report
         uses: romeovs/lcov-reporter-action@v0.2.16
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           lcov-file: ./lcov.info
+          lcov-base: base_coverage/lcov.info
 
   test-download-artifact:
     name: Download coverage artifact
     runs-on: ubuntu-18.04
+    if: false
     steps:
       - name: download artifact
         uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
           name: my-artifact
 
       - name: Apply code coverage report
-        uses: romeovs/lcov-reporter-action@v0.2.16
+        uses: romeovs/lcov-reporter-action@v0.2.19
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           lcov-file: ./lcov.info

--- a/sample1/tests/test.rs
+++ b/sample1/tests/test.rs
@@ -2,3 +2,7 @@
 fn test_hello() {
     sample1::hello();
 }
+
+fn test_world() {
+    sample1::world();
+}

--- a/sample1/tests/test.rs
+++ b/sample1/tests/test.rs
@@ -3,6 +3,7 @@ fn test_hello() {
     sample1::hello();
 }
 
+#[test]
 fn test_world() {
     sample1::world();
 }


### PR DESCRIPTION
#7 でmaster push時にcoverage結果をartifactとして出力するようにした。
それに対応して、このPRではそれをdownloadする事を試す